### PR TITLE
Refactor & simplify parsing

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -437,4 +437,26 @@ mod test {
 
         assert_eq!(token, parse_token(line).unwrap());
     }
+
+    #[test]
+    fn test_sentence_split() {
+        let s = "foo\nbar\n\nfoo\nbaz";
+
+        let mut splitter = SentenceSplitter::new(s);
+
+        assert_eq!(splitter.next(), Some("foo\nbar"));
+        assert_eq!(splitter.next(), Some("foo\nbaz"));
+        assert!(splitter.next().is_none());
+    }
+
+    #[test]
+    fn test_sentence_split_trailing_newline() {
+        let s = "foo\nbar\n\nfoo\nbaz\n";
+
+        let mut splitter = SentenceSplitter::new(s);
+
+        assert_eq!(splitter.next(), Some("foo\nbar"));
+        assert_eq!(splitter.next(), Some("foo\nbaz\n"));
+        assert!(splitter.next().is_none());
+    }
 }

--- a/tests/example.conllu
+++ b/tests/example.conllu
@@ -6,3 +6,4 @@
 4	sell	sell	VERB	VBP	Number=Plur|Person=4|Tense=Pres	2	conj	0:root|2:conj	_
 6	books	book	NOUN	NNS	Number=Plur	2	obj	2:obj|4:obj	SpaceAfter=No
 7	.	.	PUNCT	.	_	2	punct	2:punct	_
+

--- a/tests/file_parse_test.rs
+++ b/tests/file_parse_test.rs
@@ -10,9 +10,11 @@ use rs_conllu::{
 fn test_file_parse() {
     let file = File::open("./tests/example.conllu").unwrap();
 
-    let s = parse_file(file).unwrap().into_iter().next().unwrap();
+    let mut sentence_iter = parse_file(file).unwrap().into_iter();
 
-    let mut token_iter = s.into_iter();
+    let s1 = sentence_iter.next().unwrap();
+
+    let mut token_iter = s1.into_iter();
 
     let token = token_iter.next().unwrap();
 
@@ -42,5 +44,7 @@ fn test_file_parse() {
             ]),
             misc: None
         }
-    )
+    );
+
+    assert!(sentence_iter.next().is_none());
 }


### PR DESCRIPTION
Simplify the parsing process. Get rid of incremental parsing with `BufReader` and just read and process a whole document. This should not be a bottleneck with CoNLLU files.